### PR TITLE
fix wonky reboot messaging

### DIFF
--- a/install.go
+++ b/install.go
@@ -22,10 +22,10 @@ import (
 	"time"
 
 	"flag"
-	"github.com/google/cabbie/notification"
 	"github.com/google/cabbie/cablib"
 	"github.com/google/cabbie/download"
 	"github.com/google/cabbie/install"
+	"github.com/google/cabbie/notification"
 	"github.com/google/cabbie/search"
 	"github.com/google/cabbie/session"
 	"github.com/google/cabbie/updatecollection"
@@ -179,6 +179,7 @@ func (i *installCmd) installUpdates() error {
 		if rebootRequired {
 			if i.Interactive {
 				fmt.Println("Host has existing updates pending reboot.")
+				rebootEvent <- rebootRequired
 				return nil
 			}
 			t, err := cablib.RebootTime()
@@ -349,6 +350,7 @@ func (i *installCmd) installUpdates() error {
 	if rebootRequired {
 		if i.Interactive {
 			fmt.Println("Updates have been installed, please reboot to complete the installation...")
+			rebootEvent <- rebootRequired
 			return nil
 		}
 		rebootMessage(int(config.RebootDelay))


### PR DESCRIPTION
Old:

Host has existing updates pending reboot.
No reboot needed.

New:

Host has existing updates pending reboot.
Please reboot to finalize the update installation.